### PR TITLE
[BrokenLinksH2] -- update Teams connector link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This is an example to show how to write a connector for Microsoft Teams using Gi
 ### How to Run
  - install all the dependencies through npm install.
  - run node server.js.
- - Zip manifest.json file and sideload to any team. Alternative you can set your own connector at Microsoft connector portal (https://outlook.office.com/connectors/publish) and follow instructions here to get a new connector for microsoft teams ( https://msdn.microsoft.com/en-us/microsoft-teams/connectors).
+ - Zip manifest.json file and sideload to any team. Alternative you can set your own connector at the [Microsoft connector portal](https://outlook.office.com/connectors/publish) and follow instructions here to get a new connector for [Microsoft Teams](https://docs.microsoft.comoutlook/actionable-messages/connectors-dev-dashboard#build-your-own-connector).
 
 ## Contributing
 


### PR DESCRIPTION
**Global effort to fix broken links** 

@goelashish7 

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!


